### PR TITLE
feat: Add support for bitbucket and gitlab

### DIFF
--- a/src/utils/gitRemoteUrl.ts
+++ b/src/utils/gitRemoteUrl.ts
@@ -31,7 +31,6 @@ function gitRemoteUrl(content: string) {
   const config = parseIni(content);
   const url = config['remote "origin"']?.url;
   const parsedUrl = GitUrlParse(url);
-  console.log(parsedUrl);
   return `${parsedUrl.resource}/${parsedUrl.full_name}`;
 }
 


### PR DESCRIPTION
Broke out a `GitHost` enum to support not only Github, but also Bitbucket and Gitlab. They each build their URL in slightly different ways, including highlighting line numbers. Hopefully this helps people not on Github share code with ease! 